### PR TITLE
Fix font rendering in iOS 13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - Enables building the CocoaPod with `CLANG_MODULES_ENABLED=NO` which enables compiling with `ccache`.
 
+##### Hot Fixes & Enhancements
+- Fixed the text input font rendering in iOS 13
+
 ## [Version 1.9.6](https://github.com/slackhq/SlackTextViewController/releases/tag/v1.9.6)
 
 This release includes many iOS 11 and iPhone X hot fixes.

--- a/Source/SLKTextView.m
+++ b/Source/SLKTextView.m
@@ -506,18 +506,18 @@ SLKPastableMediaType SLKPastableMediaTypeFromNSString(NSString *string)
 {
     NSString *contentSizeCategory = [[UIApplication sharedApplication] preferredContentSizeCategory];
     
-    [self setFontName:font.fontName pointSize:font.pointSize withContentSizeCategory:contentSizeCategory];
+    [self setFont:font pointSize:font.pointSize withContentSizeCategory:contentSizeCategory];
     
     self.initialFontSize = font.pointSize;
 }
 
-- (void)setFontName:(NSString *)fontName pointSize:(CGFloat)pointSize withContentSizeCategory:(NSString *)contentSizeCategory
+- (void)setFont:(UIFont *)font pointSize:(CGFloat)pointSize withContentSizeCategory:(NSString *)contentSizeCategory
 {
     if (self.isDynamicTypeEnabled) {
         pointSize += SLKPointSizeDifferenceForCategory(contentSizeCategory);
     }
     
-    UIFont *dynamicFont = [UIFont fontWithName:fontName size:pointSize];
+    UIFont *dynamicFont = [font fontWithSize:pointSize];
     
     [super setFont:dynamicFont];
     
@@ -535,7 +535,7 @@ SLKPastableMediaType SLKPastableMediaTypeFromNSString(NSString *string)
     
     NSString *contentSizeCategory = [[UIApplication sharedApplication] preferredContentSizeCategory];
 
-    [self setFontName:self.font.fontName pointSize:self.initialFontSize withContentSizeCategory:contentSizeCategory];
+    [self setFont:self.font pointSize:self.initialFontSize withContentSizeCategory:contentSizeCategory];
 }
 
 - (void)setTextAlignment:(NSTextAlignment)textAlignment
@@ -906,7 +906,7 @@ SLKPastableMediaType SLKPastableMediaTypeFromNSString(NSString *string)
     
     NSString *contentSizeCategory = notification.userInfo[UIContentSizeCategoryNewValueKey];
     
-    [self setFontName:self.font.fontName pointSize:self.initialFontSize withContentSizeCategory:contentSizeCategory];
+    [self setFont:self.font pointSize:self.initialFontSize withContentSizeCategory:contentSizeCategory];
     
     NSString *text = [self.text copy];
     


### PR DESCRIPTION
* [X] I've read and understood the [Contributing guidelines](https://github.com/slackhq/SlackTextViewController/blob/master/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://github.com/slackhq/SlackTextViewController/blob/master/.github/CODE_OF_CONDUCT.md).
* [X] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [X] I've added a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [X] I've listed my changes on the [Changelog(https://github.com/slackhq/SlackTextViewController/blob/master/CHANGELOG.md) file.
* [ ] ~~I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).~~

#### PR Summary

`[UIfont fontWithName:pointSize:]` returns Times New Roman when passed the
name of a font returned from `[UIFont systemFontWithSize:]`. So rather
than going via the font name, we use the more general instance method
`[font fontWithSize:]` which duplicates the exact font just with the
appropriate size.


#### Related Issues

https://gitlab.com/gitlab-org/gitter/gitter-ios-app/merge_requests/8

#### Test strategy

https://gitlab.com/gitlab-org/gitter/gitter-ios-app/merge_requests/8